### PR TITLE
Patch 1.18 fixes (somewhat)

### DIFF
--- a/F1-2020 Names Changer/F1-2020 Names Changer.csproj
+++ b/F1-2020 Names Changer/F1-2020 Names Changer.csproj
@@ -40,6 +40,7 @@
     </StartupObject>
   </PropertyGroup>
   <ItemGroup>
+    <Reference Include="Microsoft.VisualBasic" />
     <Reference Include="Microsoft.Win32.Primitives, Version=4.0.2.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Win32.Primitives.4.3.0\lib\net46\Microsoft.Win32.Primitives.dll</HintPath>
       <Private>True</Private>

--- a/F1-2020 Names Changer/Form1.Designer.cs
+++ b/F1-2020 Names Changer/Form1.Designer.cs
@@ -83,6 +83,7 @@
 			this.gameRegionIndicator = new System.Windows.Forms.ToolStripButton();
 			this.logBox = new System.Windows.Forms.RichTextBox();
 			this.toolTip1 = new System.Windows.Forms.ToolTip(this.components);
+			this.findOffsetsWithCustomStartToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
 			this.menuStrip1.SuspendLayout();
 			((System.ComponentModel.ISupportInitialize)(this.splitContainer1)).BeginInit();
 			this.splitContainer1.Panel1.SuspendLayout();
@@ -206,7 +207,7 @@
 			// 
 			this.undoToolStripMenuItem.Name = "undoToolStripMenuItem";
 			this.undoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Z)));
-			this.undoToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+			this.undoToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.undoToolStripMenuItem.Text = "&Undo";
 			this.undoToolStripMenuItem.Click += new System.EventHandler(this.undoToolStripMenuItem_Click);
 			// 
@@ -214,14 +215,14 @@
 			// 
 			this.redoToolStripMenuItem.Name = "redoToolStripMenuItem";
 			this.redoToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Y)));
-			this.redoToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+			this.redoToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.redoToolStripMenuItem.Text = "&Redo";
 			this.redoToolStripMenuItem.Click += new System.EventHandler(this.redoToolStripMenuItem_Click);
 			// 
 			// toolStripSeparator7
 			// 
 			this.toolStripSeparator7.Name = "toolStripSeparator7";
-			this.toolStripSeparator7.Size = new System.Drawing.Size(141, 6);
+			this.toolStripSeparator7.Size = new System.Drawing.Size(177, 6);
 			// 
 			// cutToolStripMenuItem
 			// 
@@ -229,7 +230,7 @@
 			this.cutToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.cutToolStripMenuItem.Name = "cutToolStripMenuItem";
 			this.cutToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.X)));
-			this.cutToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+			this.cutToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.cutToolStripMenuItem.Text = "Cu&t";
 			this.cutToolStripMenuItem.Click += new System.EventHandler(this.cutToolStripMenuItem_Click);
 			// 
@@ -239,7 +240,7 @@
 			this.copyToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.copyToolStripMenuItem.Name = "copyToolStripMenuItem";
 			this.copyToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.C)));
-			this.copyToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+			this.copyToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.copyToolStripMenuItem.Text = "&Copy";
 			this.copyToolStripMenuItem.Click += new System.EventHandler(this.copyToolStripMenuItem_Click);
 			// 
@@ -249,31 +250,31 @@
 			this.pasteToolStripMenuItem.ImageTransparentColor = System.Drawing.Color.Magenta;
 			this.pasteToolStripMenuItem.Name = "pasteToolStripMenuItem";
 			this.pasteToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.V)));
-			this.pasteToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+			this.pasteToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.pasteToolStripMenuItem.Text = "&Paste";
 			this.pasteToolStripMenuItem.Click += new System.EventHandler(this.pasteToolStripMenuItem_Click);
 			// 
 			// toolStripSeparator8
 			// 
 			this.toolStripSeparator8.Name = "toolStripSeparator8";
-			this.toolStripSeparator8.Size = new System.Drawing.Size(141, 6);
+			this.toolStripSeparator8.Size = new System.Drawing.Size(177, 6);
 			// 
 			// selectAllToolStripMenuItem
 			// 
 			this.selectAllToolStripMenuItem.Name = "selectAllToolStripMenuItem";
-			this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+			this.selectAllToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.selectAllToolStripMenuItem.Text = "Select &All";
 			this.selectAllToolStripMenuItem.Click += new System.EventHandler(this.selectAllToolStripMenuItem_Click);
 			// 
 			// toolStripSeparator3
 			// 
 			this.toolStripSeparator3.Name = "toolStripSeparator3";
-			this.toolStripSeparator3.Size = new System.Drawing.Size(141, 6);
+			this.toolStripSeparator3.Size = new System.Drawing.Size(177, 6);
 			// 
 			// fontToolStripMenuItem
 			// 
 			this.fontToolStripMenuItem.Name = "fontToolStripMenuItem";
-			this.fontToolStripMenuItem.Size = new System.Drawing.Size(144, 22);
+			this.fontToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
 			this.fontToolStripMenuItem.Text = "Font";
 			this.fontToolStripMenuItem.Click += new System.EventHandler(this.fontToolStripMenuItem_Click);
 			// 
@@ -284,6 +285,7 @@
             this.stopToolStripMenuItem,
             this.undoChangesToolStripMenuItem,
             this.findOffsetsToolStripMenuItem,
+            this.findOffsetsWithCustomStartToolStripMenuItem,
             this.useCustomOffset});
 			this.gameToolStripMenuItem.Name = "gameToolStripMenuItem";
 			this.gameToolStripMenuItem.Size = new System.Drawing.Size(50, 20);
@@ -292,14 +294,14 @@
 			// writeToF1ToolStripMenuItem
 			// 
 			this.writeToF1ToolStripMenuItem.Name = "writeToF1ToolStripMenuItem";
-			this.writeToF1ToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.writeToF1ToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
 			this.writeToF1ToolStripMenuItem.Text = "Write to F1";
 			this.writeToF1ToolStripMenuItem.Click += new System.EventHandler(this.writeToF1ToolStripMenuItem_Click_1);
 			// 
 			// stopToolStripMenuItem
 			// 
 			this.stopToolStripMenuItem.Name = "stopToolStripMenuItem";
-			this.stopToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.stopToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
 			this.stopToolStripMenuItem.Text = "Stop";
 			this.stopToolStripMenuItem.Click += new System.EventHandler(this.stopToolStripMenuItem_Click);
 			// 
@@ -307,14 +309,14 @@
 			// 
 			this.undoChangesToolStripMenuItem.Enabled = false;
 			this.undoChangesToolStripMenuItem.Name = "undoChangesToolStripMenuItem";
-			this.undoChangesToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.undoChangesToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
 			this.undoChangesToolStripMenuItem.Text = "Undo Changes";
 			this.undoChangesToolStripMenuItem.Click += new System.EventHandler(this.undoChangesToolStripMenuItem_Click);
 			// 
 			// findOffsetsToolStripMenuItem
 			// 
 			this.findOffsetsToolStripMenuItem.Name = "findOffsetsToolStripMenuItem";
-			this.findOffsetsToolStripMenuItem.Size = new System.Drawing.Size(180, 22);
+			this.findOffsetsToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
 			this.findOffsetsToolStripMenuItem.Text = "Find Offsets";
 			this.findOffsetsToolStripMenuItem.Click += new System.EventHandler(this.findOffsetsToolStripMenuItem_Click);
 			// 
@@ -322,7 +324,7 @@
 			// 
 			this.useCustomOffset.CheckOnClick = true;
 			this.useCustomOffset.Name = "useCustomOffset";
-			this.useCustomOffset.Size = new System.Drawing.Size(180, 22);
+			this.useCustomOffset.Size = new System.Drawing.Size(235, 22);
 			this.useCustomOffset.Text = "Use Custom Offset";
 			// 
 			// helpToolStripMenuItem1
@@ -647,6 +649,13 @@
 			this.logBox.Text = "";
 			this.logBox.TextChanged += new System.EventHandler(this.logBox_TextChanged);
 			// 
+			// findOffsetsWithCustomStartToolStripMenuItem
+			// 
+			this.findOffsetsWithCustomStartToolStripMenuItem.Name = "findOffsetsWithCustomStartToolStripMenuItem";
+			this.findOffsetsWithCustomStartToolStripMenuItem.Size = new System.Drawing.Size(235, 22);
+			this.findOffsetsWithCustomStartToolStripMenuItem.Text = "Find Offsets with Custom Start";
+			this.findOffsetsWithCustomStartToolStripMenuItem.Click += new System.EventHandler(this.findOffsetsWithCustomStartToolStripMenuItem_Click);
+			// 
 			// Form1
 			// 
 			this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
@@ -746,5 +755,6 @@
 		private System.Windows.Forms.ToolStripButton lookupIndicator;
 		private System.Windows.Forms.ToolStripMenuItem findOffsetsToolStripMenuItem;
 		private System.Windows.Forms.ToolStripMenuItem useCustomOffset;
+		private System.Windows.Forms.ToolStripMenuItem findOffsetsWithCustomStartToolStripMenuItem;
 	}
 }

--- a/F1-2020 Names Changer/Form1.cs
+++ b/F1-2020 Names Changer/Form1.cs
@@ -1,4 +1,5 @@
-﻿using NLog;
+﻿using Microsoft.VisualBasic;
+using NLog;
 using System;
 using System.Collections.Generic;
 using System.ComponentModel;
@@ -31,6 +32,8 @@ namespace F1_2020_Names_Changer {
 			filePath.Text = Directory.GetCurrentDirectory();
 
 			checkForDefaultLookups();
+
+			log.Info("Due to the newest F1 2020 patch, it may be quicker in some cases (or the only way in others!) to use 'Cheat Engine' to find the term {o:mixed}Carlos{/o} as a custom start in Find Offsets rather than letting it search.");
 		}
 
 		private void writeToF1ToolStripMenuItem_Click_1(object sender, EventArgs e) {
@@ -458,6 +461,20 @@ namespace F1_2020_Names_Changer {
 					break;
 			}
 			return bHandled;
+		}
+
+		private void findOffsetsWithCustomStartToolStripMenuItem_Click(object sender, EventArgs e) {
+			String retstr = Interaction.InputBox("Enter the hex offset of the start of the search", "Search Offset");
+			try {
+				long offset = Convert.ToInt64(retstr, 16);
+				offset -= 0x00500000000; // give some search room
+				Task.Run(() => MemoryChanger.findOffsets(offset,99,(long)5e10));
+				useCustomOffset.Checked = true;
+				haveShownCustomOffsetsPopup = true;
+				toolStripProgressBar1.Style = ProgressBarStyle.Marquee;
+			} catch (FormatException) {
+				log.Fatal("Input search offset was not a valid hex string");
+			}
 		}
 	}
 }

--- a/F1-2020 Names Changer/Form1.cs
+++ b/F1-2020 Names Changer/Form1.cs
@@ -474,6 +474,8 @@ namespace F1_2020_Names_Changer {
 				toolStripProgressBar1.Style = ProgressBarStyle.Marquee;
 			} catch (FormatException) {
 				log.Fatal("Input search offset was not a valid hex string");
+			} catch (System.ArgumentOutOfRangeException) {
+				// nothing - cancel was pressed / closed
 			}
 		}
 	}

--- a/F1-2020 Names Changer/Form1.resx
+++ b/F1-2020 Names Changer/Form1.resx
@@ -225,22 +225,22 @@
   <data name="toolStripButtonStop.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">
     <value>
         iVBORw0KGgoAAAANSUhEUgAAADAAAAAwCAYAAABXAvmHAAAAAXNSR0IArs4c6QAAAARnQU1BAACxjwv8
-        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAANsSURBVGhD7VnLbhMxFI14LVjyWPH4AFbAjE2KKo0yDhEL
-        thEIlqxZU0CiAqSWfVsB6icgYEGLBEj8A6h8AI8VCajNJFGgTYyvc4OmyZ3EM55MipQjHant2NfHM/b1
-        8W1uiimmsIcsl/c3BZup+/yu4ou6cD7XhfurIvgfIPxcF3xDP1NtGkWel/O5fdh9cmiW3FOB4I83hfNd
-        CZRxuCXOfwt8vtjw+EkMlx1ql88eD3z2rOLx35S4OIQY6iU8qXnOMQw/XgSCXa97535SYqw4y6uBf+Ea
-        DpM+pOMcVG9qlRw8RaoX9BTGwmHTgbziHK4J/oYacBysCbYOY+LwdoC3kaX4fyzw97J85hDKSI4slk0U
-        YXOjjGRQ6/EGFThLBsK9inLiYUuwoypApT9g5lQZL1GKhTxPBpwEfb6CsswAp2OsQ6qYl81bN+lnBHVb
-        1Yd6RhG0NIvOaZQ3GmAPqEAklZDtt2tSttuytThPtwmx9fCOlDs7cvvDO1kvzZBtKILtQHnDASYLfAoV
-        ZIA98T2MmERPfA9xJgF+C0wjyoyGdpVEAIqwFMKCNNTvrUf3BtrC36i2cZZew3c4yoyGtsRE5yi2HswN
-        Cuv7Ev1vXgPaLNzfFWski2wOZUZDrf+XZOchHDaJ1MRrsucoMxqq4cZgx9EkJ9Fpa7G7kFi8YoF9QpnR
-        sLHK5CTCsBHfZQVlRsP2kqIn0f/WAZ2OrXhZvchbKDMa1hOANU9OoLsnqD6mNJqA1RKiNmwYsITsJjF6
-        CalGyTYxJV4tm4GvYTMJk02cKI0OSZUm54Q5TdJo3IPMIM+nNgmf3UaZ0YCiE9mZYOZWQrgMZUZDm7kC
-        /0oFGCBl5oakyv4voc3cJTNbXfP4F+NqHlhXKgjJsJ02yPO9ScQRD1QXrAWUNxp77UID+b/h50+gPDNA
-        RYAKNhmyJZRljs1S/ojqPPlL/SyvJq6bQq2SDJoh1X4so5xkgFolFTgbsmWUkRxwDw2E+4oeYHwMfHdN
-        et4BlGGHbnGXrVMDjYNBgb9OrbjbA5bXM8hMbDm1N08BapVqoPSzk89/WG9YU+i6qc9X4IAhxcRgNwZb
-        grSN4bMDnI5gO4y9U4jQB+xB7BN2HACTBUUnqNuAZ4eLB9zswI5oS6Jvee5H/UxZYnCVe+LfrFNM8d8j
-        l/sLOKsjnPMPf9UAAAAASUVORK5CYII=
+        YQUAAAAJcEhZcwAADsMAAA7DAcdvqGQAAANsSURBVGhD7VnLbhMxFI14LVjyWPH4AFbAjE0qVRplHCIW
+        bCMQLFmzpoBEBUgt+7YCxCdUwIIWCZD4B1D5AB6rNKA2k0SBNjG+zg1KM3cSz3gyKVKOdKS2Y18fz9jX
+        x7e5KaaYwh6yXD7YFGym7vN7ii/rwvlSF+6viuB/gPBzXfAN/Uy1aRR5Xs7nDmD3yaFZcs8Egj/ZEs4P
+        JVDG4ba4+D3w+WLD46cxXHaoXTl/MvDZ84rHf1Pi4hBiqJfwtOY5JzD8eBEIdqPuXfhJibHiLK8G/qXr
+        OEz6kI5zWL2pF+TgKVK9oGcwFg6bDuRV52hN8LfUgONgTbB1GBOHtwO8jSzF/2OBf5Dlc0dQRnJksWyi
+        CJsbZSSDWo83qcBZMhDuNZQTD9uCHVcBNgcDZk6V8RKlWMjzZMBJ0OcrKMsMcDrGOqSKedm8fYt+RlC3
+        VX2oZxRBS7PonEV5owH2gApEUgnZebcmZbstW4vzdJs+th7dlXJ3V+58fC/rpRmyDUWwHShvOMBkgU+h
+        goTYE9/DiEn0xPcQZxLgt8A0osxoaFdJBKAIS6FfkIb6vfX4fqgt/I1qG2fpNXyHo8xoaEtMdI5i6+Fc
+        WNjAlxh88xrQZuHBnlgjWWRzKDMaav2/IjsP4bBJpCZek62izGiohhvhjqNJTqLT1mL3ILF4xQL7jDKj
+        YWOVyUn0w0Z8l5soMxq2lxQ9icG3Duh0bMXL6gxvocxoWE8A1jw5ge6eoPqY0mgCVkuI2rD9gCVkN4nR
+        S0g1SraJKfFq2YS+hs0kTDZxojQ6JFWanBPmNEmjcQ8ygzyf2iR8dgdlRgOKTmRngplbCeEylBkNbeYK
+        /BsVIETKzA1JlYNfQpu5y2a2uubxr8bVPLCuVBCS/XbaIM/3JhFHPFBdsBZQ3mjstwsN5P+Gnz+F8swA
+        FQEq2GTIllCWObZK+WOq8+Qv9bO8mrhuCrVKMmiGVPuxjHKSAWqVVOBsyJZRRnLAPTQQ7mt6gPEx8N01
+        6XmHUIYdusVdtk4NNA4GBf4mteJuD1hezyAzseXU3jwFqFWqgdLPTj6vWG9YU+i6qc9X4IAhxcRgNwZb
+        grSN4bMDnI5gO4y9Ux+hD9iD2CfsOAAmC4pOULcBzw4XD7jZgR3RlkTf8txP+pmyxOAq98W/WaeY4r9H
+        LvcXFwkjjIEJTH8AAAAASUVORK5CYII=
 </value>
   </data>
   <data name="toolStripButtonUndo.Image" type="System.Drawing.Bitmap, System.Drawing" mimetype="application/x-microsoft.net.object.bytearray.base64">

--- a/F1-2020 Names Changer/Offsets.cs
+++ b/F1-2020 Names Changer/Offsets.cs
@@ -8,7 +8,8 @@ using System.Threading.Tasks;
 namespace F1_2020_Names_Changer {
 	static class Offsets {
 
-		public static IntPtr SEARCH_START = (IntPtr)0x190000000; // used for searching for below offsets if they don't work
+		public static IntPtr SEARCH_START = (IntPtr)0x1b000000000; // used for searching for below offsets if they don't work
+        public static IntPtr SEARCH_START_ALT = (IntPtr)0x21000000000;
 
 		// these are addresses at which this program will start to search for the below search strings to identify the where the actual start of the region is
 		public static IntPtr MENU_OFFSET_START;

--- a/Readme.md
+++ b/Readme.md
@@ -4,7 +4,27 @@ I wrote this rather than using cheat engine, as I felt the scripting tools avail
 
 Current stable version: https://github.com/Electronics/F1NameChanger/releases/tag/latest
 
-See [Issue #15](https://github.com/Electronics/F1NameChanger/issues/15) for latest on 1.18 game patch
+# 1.18 Patch Woes
+
+(copied from https://github.com/Electronics/F1NameChanger/pull/20)
+
+Patch 1.18 of the F1 2020 game has proven rather problematic... The memory address space used has apparently increased by 256x meaning my magic fix of Find Offsets a bit more non-solutioney. To trawl through all memory space used would take hours with the way I search for the various bits and bobs.
+
+The fixes (or work-arounds) I have made:
+
+    The default Find Offsets now considers 2, larger, memory ranges. This now actually takes up to minutes to search through sadly.
+    In some cases, this will still not find the correct starting addresses
+    Added a new Find Offsets with Custom Start option in the Game menu. This allows for the search process to start at a specified address given in the popup in hexadecimal.
+
+tl;dr or how to make the F1NameChanger work now
+
+If you want the quickest and most reliable method follow these steps:
+
+    Use Cheat Engine to scan the F1 process for the Value Type: string of {o:mixed}Carlos{/o}.
+    There should only be one result, copy and paste the resulting address (Ctrl+C works) into popup searh offset of the new item Game -> Find Offsets with Custom Start
+    Should work as before!
+    This will likely need to be repeated every time the game starts :(
+
 
 # Running
 

--- a/Readme.md
+++ b/Readme.md
@@ -12,18 +12,18 @@ Patch 1.18 of the F1 2020 game has proven rather problematic... The memory addre
 
 The fixes (or work-arounds) I have made:
 
-    The default Find Offsets now considers 2, larger, memory ranges. This now actually takes up to minutes to search through sadly.
-    In some cases, this will still not find the correct starting addresses
-    Added a new Find Offsets with Custom Start option in the Game menu. This allows for the search process to start at a specified address given in the popup in hexadecimal.
+- The default Find Offsets now considers 2, larger, memory ranges. This now actually takes up to minutes to search through sadly.
+- In some cases, this will still not find the correct starting addresses
+- Added a new Find Offsets with Custom Start option in the Game menu. This allows for the search process to start at a specified address given in the popup in hexadecimal.
 
-tl;dr or how to make the F1NameChanger work now
+## tl;dr or how to make the F1NameChanger work now
 
 If you want the quickest and most reliable method follow these steps:
 
-    Use Cheat Engine to scan the F1 process for the Value Type: string of {o:mixed}Carlos{/o}.
-    There should only be one result, copy and paste the resulting address (Ctrl+C works) into popup searh offset of the new item Game -> Find Offsets with Custom Start
-    Should work as before!
-    This will likely need to be repeated every time the game starts :(
+1. Use Cheat Engine to scan the F1 process for the Value Type: string of {o:mixed}Carlos{/o}.
+2. There should only be one result, copy and paste the resulting address (Ctrl+C works) into popup searh offset of the new item Game -> Find Offsets with Custom Start
+3. Should work as before!
+4. This will likely need to be repeated every time the game starts :(
 
 
 # Running

--- a/Readme.md
+++ b/Readme.md
@@ -20,7 +20,7 @@ The fixes (or work-arounds) I have made:
 
 If you want the quickest and most reliable method follow these steps:
 
-1. Use Cheat Engine to scan the F1 process for the Value Type: string of {o:mixed}Carlos{/o}.
+1. Use [Cheat Engine](https://www.cheatengine.org/) to scan the F1 process for the Value Type: string of {o:mixed}Carlos{/o}.
 2. There should only be one result, copy and paste the resulting address (Ctrl+C works) into popup searh offset of the new item Game -> Find Offsets with Custom Start
 3. Should work as before!
 4. This will likely need to be repeated every time the game starts :(


### PR DESCRIPTION
Patch 1.18 of the F1 2020 game has proven rather problematic... The memory address space used has apparently increased by 256x meaning my magic fix of `Find Offsets` a bit more non-solutioney. To trawl through all memory space used would take hours with the way I search for the various bits and bobs.

The fixes (or work-arounds) I have made:

- The default `Find Offsets` now considers **2**, larger, memory ranges. This now actually takes up to minutes to search through sadly.
- In some cases, this will still not find the correct starting addresses
- Added a new `Find Offsets with Custom Start` option in the `Game` menu. This allows for the search process to start at a specified address given in the popup in hexadecimal.

### tl;dr or how to make the F1NameChanger work now

If you want the quickest and most reliable method follow these steps:

1. Use [Cheat Engine](https://www.cheatengine.org/) to scan the F1 process for the `Value Type`: `string` of `{o:mixed}Carlos{/o}`.
2. There should only be one result, copy and paste the resulting address (`Ctrl+C` works) into popup searh offset of the new item `Game -> Find Offsets with Custom Start`
3. Should work as before!
4. This will likely need to be repeated every time the game starts :(

This should fix #19 #15 #18 #17 